### PR TITLE
Refactor: 전역 예외 처리 기능 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/code/ErrorCode.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/code/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.exception.code
+
+import org.springframework.http.HttpStatus
+
+interface ErrorCode {
+    val errorName: String
+    val status: HttpStatus
+    var bodyMessage: String
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CommonErrorCode.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CommonErrorCode.kt
@@ -1,0 +1,16 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class CommonErrorCode(
+    override val status: HttpStatus,
+    override var bodyMessage: String
+) : ErrorCode {
+
+    ENTITY_NOT_FOUND_ERR(HttpStatus.NOT_FOUND, "존재하지 않는 Entity 입니다"),
+    INTERNAL_SERVER_ERR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생하였습니다."),
+    INVALID_ARGS_ERR(HttpStatus.BAD_REQUEST, "주어진 입력값이 올바르지 않습니다.");
+
+    override val errorName: String = name
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CustomIllegalArgumentException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CustomIllegalArgumentException.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+
+class CustomIllegalArgumentException(
+    override val errorCode: ErrorCode = CommonErrorCode.INVALID_ARGS_ERR,
+    override val errorMessage: String = errorCode.bodyMessage
+) : RestApiException(errorMessage) {
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+
+class NoSuchEntityException(
+    override val errorCode: ErrorCode = CommonErrorCode.ENTITY_NOT_FOUND_ERR,
+    override val errorMessage: String = errorCode.bodyMessage,
+) : RestApiException(errorMessage) {
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
@@ -4,6 +4,6 @@ import com.sparta.bubbleclub.global.exception.code.ErrorCode
 
 class NoSuchEntityException(
     override val errorCode: ErrorCode = CommonErrorCode.ENTITY_NOT_FOUND_ERR,
-    override val errorMessage: String = errorCode.bodyMessage,
-) : RestApiException(errorCode) {
+    override val errorMessage: String
+) : RestApiException(errorMessage) {
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/NoSuchEntityException.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+
+class NoSuchEntityException(
+    override val errorCode: ErrorCode = CommonErrorCode.ENTITY_NOT_FOUND_ERR,
+    override val errorMessage: String = errorCode.bodyMessage,
+) : RestApiException(errorCode) {
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/RestApiException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/RestApiException.kt
@@ -1,0 +1,16 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import java.lang.RuntimeException
+
+abstract class RestApiException : RuntimeException {
+
+    abstract val errorCode: ErrorCode
+
+    abstract val errorMessage: String
+
+    constructor() : super()
+
+    constructor(errorMessage: String) : super(errorMessage)
+    
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/RestApiException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/RestApiException.kt
@@ -1,0 +1,17 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import java.lang.RuntimeException
+
+abstract class RestApiException : RuntimeException {
+
+    abstract val errorCode: ErrorCode
+
+    abstract val errorMessage: String
+
+    constructor() : super()
+
+    constructor(errorMessage: String) : super(errorMessage)
+
+    constructor(errorCode: ErrorCode) : this(errorCode.bodyMessage)
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/handler/RestApiExceptionHandler.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/handler/RestApiExceptionHandler.kt
@@ -1,0 +1,38 @@
+package com.sparta.bubbleclub.global.exception.handler
+
+import com.sparta.bubbleclub.global.exception.common.CommonErrorCode
+import com.sparta.bubbleclub.global.exception.common.RestApiException
+import com.sparta.bubbleclub.global.exception.response.ErrorResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class RestApiExceptionHandler {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @ExceptionHandler
+    fun handleInternalServerException(exception: RuntimeException): ResponseEntity<ErrorResponse> {
+        logger.warn(exception::class.simpleName, exception)
+        return makeResponse(ErrorResponse.of(CommonErrorCode.INTERNAL_SERVER_ERR))
+    }
+
+    @ExceptionHandler
+    fun handleMethodArgumentNotValidException(exception: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        logger.warn(exception::class.simpleName, exception)
+        return makeResponse(ErrorResponse.of(CommonErrorCode.INVALID_ARGS_ERR, exception.bindingResult))
+    }
+
+    @ExceptionHandler
+    fun handleRestApiException(exception: RestApiException): ResponseEntity<ErrorResponse> {
+        logger.warn(exception::class.simpleName, exception) // 추후 AOP 적용 예상
+        return makeResponse(ErrorResponse.of(exception.errorCode, exception.errorMessage))
+    }
+
+    private fun makeResponse(response: ErrorResponse): ResponseEntity<ErrorResponse> {
+        return ResponseEntity.status(response.code).body(response)
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/member/DuplicateArgumentException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/member/DuplicateArgumentException.kt
@@ -1,0 +1,10 @@
+package com.sparta.bubbleclub.global.exception.member
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import com.sparta.bubbleclub.global.exception.common.RestApiException
+
+class DuplicateArgumentException(
+    override val errorCode: ErrorCode = MemberErrorCode.DUPLICATE_ARGS_ERR,
+    override val errorMessage: String = errorCode.bodyMessage
+) : RestApiException(errorMessage) {
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/member/MemberErrorCode.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/member/MemberErrorCode.kt
@@ -1,0 +1,14 @@
+package com.sparta.bubbleclub.global.exception.member
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class MemberErrorCode(
+    override val status: HttpStatus,
+    override var bodyMessage: String
+) : ErrorCode {
+
+    DUPLICATE_ARGS_ERR(HttpStatus.BAD_REQUEST, "중복되는 입력값이 존재합니다.");
+
+    override val errorName = name
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/response/ErrorResponse.kt
@@ -1,0 +1,53 @@
+package com.sparta.bubbleclub.global.exception.response
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BindingResult
+
+class ErrorResponse(
+    val code: HttpStatus,
+    val message: String,
+    val errors: List<FieldError>?
+) {
+
+    data class FieldError(
+        val field: String, // 필드명
+        val value: String, // 실제 사용자가 넘긴 값
+        val message: String // @NotNull 등 어노테이션 안의 message 필드
+    ) {
+        companion object {
+            fun of(bindingResult: BindingResult): List<FieldError> {
+                val errors = bindingResult.fieldErrors
+
+                return errors.map {
+                    FieldError(
+                        it.field,
+                        it.rejectedValue.toString(),
+                        it.defaultMessage.toString()
+                    )
+                }
+            }
+        }
+    }
+
+
+    companion object {
+        fun of(errorCode: ErrorCode) = ErrorResponse(
+            code = errorCode.status,
+            message = errorCode.bodyMessage,
+            errors = null
+        )
+
+        fun of(errorCode: ErrorCode, errorMessage: String) = ErrorResponse(
+            code = errorCode.status,
+            message = errorMessage,
+            errors = null
+        )
+
+        fun of(errorCode: ErrorCode, bindingResult: BindingResult) = ErrorResponse(
+            code = errorCode.status,
+            message = errorCode.bodyMessage,
+            errors = FieldError.of(bindingResult)
+        )
+    }
+}


### PR DESCRIPTION
- 전역 예외 처리 추상화를 위한 RestApiException 클래스 생성
- RestApiExceptionHandler 처리 방식 수정
- ErrorCode bodyMessage val -> var 변경
- ErrorResponse of 메서드 추가
- 중복 발생 에외(DuplicateArgumentExceptoin), 입력값 불일치 예외 (CustomIllegalArgumentException) 클래스 생성

## 연관 이슈
- closes #14 

## 해당 작업을 한 동기는 무엇인가요?
- 현재 예외를 처리하기 위해선 개별적인 커스텀 예외를 계속해서 만들고 이와 관련된 ExceptionHandler 메소드도 따로 생성해야 하는 불편함이 있습니다. 이를 RuntimeException을 상속한 추상 예외 클래스를 만들어 완화하고자 하였습니다.
- 또한, 같은 예외를 던져도 메시지는 다르게 표현하고 싶을 때가 있는데, 메시지를 개별로 생성하지 못하고 있어 이를 완화하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] 더 좋은 방법이 있다면 함께 고민해주시면 좋을 것 같습니다! 
- [ ] 추후에 Validatoin 적용 및 Exception을 throw 할 때 불편한 점이 생기면 말씀해주세요! 