### PR TITLE
Refactor: Bubble Pageable 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
@@ -6,6 +6,7 @@ import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
 import com.sparta.bubbleclub.global.security.web.dto.MemberPrincipal
 import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
@@ -44,10 +45,9 @@ class BubbleController(
     @GetMapping
     fun getBubbles(
         @RequestParam bubbleId: Long,
-        @RequestParam(value = "keyword") keyword: String?,
-        @PageableDefault(size = 10)  pageable: Pageable,
+        @RequestParam(value = "keyword") keyword: String?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubblesByKeyword(bubbleId, keyword, pageable))
+        return ResponseEntity.ok().body(bubbleService.getBubblesByKeyword(bubbleId, keyword, PageRequest.of(0, 10)))
     }
 
     @DeleteMapping("/{bubbleId}")


### PR DESCRIPTION
-PageableDefault 어노테이션 삭제
-PageRequest 클래스의 of 메서드로 pageSize 10 고정

## 연관 이슈
- closes #23 

## 해당 작업을 한 동기는 무엇인가요?
-불필요한 pageSize, pageNumber 요구를 제거하기 위하여 아래와 같이 작업하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- PageableDefault 어노테이션 삭제
- pageRequest 클래스의 of 메서드로 pageable 객체 생성, pageSize 10으로 고정
 