### PR TITLE
Refactor: Bubble 검색 기능 Pageable, bubbleId 파라미터 관련 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
@@ -44,7 +44,7 @@ class BubbleController(
 
     @GetMapping
     fun getBubbles(
-        @RequestParam bubbleId: Long,
+        @RequestParam bubbleId: Long?,
         @RequestParam(value = "keyword") keyword: String?
     ): ResponseEntity<Slice<BubbleResponse>> {
         return ResponseEntity.ok().body(bubbleService.getBubblesByKeyword(bubbleId, keyword, PageRequest.of(0, 10)))

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
@@ -2,6 +2,7 @@ package com.sparta.bubbleclub.domain.bubble.controller
 
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.web.PageableDefault
@@ -16,10 +17,9 @@ class BubbleControllerV2(
 
     @GetMapping
     fun getBubbles(
-        @RequestParam bubbleId: Long,
-        @RequestParam(value = "keyword") keyword: String?,
-        @PageableDefault(size = 10)  pageable: Pageable,
+        @RequestParam bubbleId: Long?,
+        @RequestParam(value = "keyword") keyword: String?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubblesByKeywordWithCaching(bubbleId, keyword, pageable))
+        return ResponseEntity.ok().body(bubbleService.getBubblesByKeywordWithCaching(bubbleId, keyword, PageRequest.of(0, 10)))
     }
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
@@ -32,7 +32,7 @@ class BubbleQueryDslRepositoryImpl(
             .innerJoin(bubble.member)
             .where(
                 ltBubbleId(bubbleId),
-                bubble.content.like("$keyword%")
+                isNullKeyword(keyword)
             )
             .orderBy(bubble.id.desc())
             .limit(pageSize + 1)
@@ -49,6 +49,15 @@ class BubbleQueryDslRepositoryImpl(
 
         return bubble.id.lt(bubbleId)
     }
+
+    private fun isNullKeyword(keyword: String?): BooleanExpression? {
+        if (keyword == null) {
+            return null
+        }
+
+        return bubble.content.like("$keyword%")
+    }
+
 
     // 마지막 페이지 확인
     private fun checkLastPage(pageable: Pageable, result: MutableList<BubbleResponse>): Slice<BubbleResponse> {

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
@@ -38,12 +38,12 @@ class BubbleService(
         return bubble.id!!
     }
 
-    fun getBubblesByKeyword(bubbleId: Long, keyword: String?, pageable: Pageable): Slice<BubbleResponse> {
+    fun getBubblesByKeyword(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse> {
         return bubbleRepository.getBubblesByKeyword(bubbleId, keyword, pageable)
     }
 
-    @Cacheable(cacheNames = ["bubbles"], key = "#keyword.concat(#bubbleId)")
-    fun getBubblesByKeywordWithCaching(bubbleId: Long, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
+    @Cacheable(cacheNames = ["bubbles"], key = "(#keyword ?: '').concat(#bubbleId ?: '')")
+    fun getBubblesByKeywordWithCaching(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
         return bubbleRepository.getBubblesByKeyword(bubbleId, keyword, pageable)
     }
 


### PR DESCRIPTION
## 연관 이슈
- closes #27 

## 해당 작업을 한 동기는 무엇인가요?
- Bubble 검색 API 호출 시 불필요한 파라미터 제거
- Bubble 검색 API 호출 시 bubbleId를 인자로 넘기지 않으면 가장 최근 Bubble들을 조회하게 함

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] Bubble 검색 기능 V2 API에서 Pageable 파라미터 제거
- [x] persistence layer에서 where절 keyword를 boolean builder로 받게 하여 keyword 인자 없이 Bubble 조회 가능하게 함
- [x] Bubble 검색 기능 V1, V2 API에서 bubbleId 파라미터를 nullable하게 변경
  - bubbleId를 인자로 넘기지 않으면 가장 최근 Bubble들을 조회하게 함
- 기타 작업 사항: BubbleService의 getBubblesByKeywordWithCaching() 메서드에서 keyword, bubbleId가 인자로 들어오지 않는 경우에도 오류가 발생하지 않도록 빈 문자열을 캐싱 키로 캐싱하게 함
