### PR TITLE
Refactor: Bubble 단순 조회/검색 API 분리 리팩토링

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ val queryDslVersion = "5.0.0"
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
@@ -1,17 +1,18 @@
 package com.sparta.bubbleclub.domain.bubble.controller
 
 import com.sparta.bubbleclub.domain.bubble.dto.request.CreateBubbleRequest
+import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.bubble.dto.request.UpdateBubbleRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
 import com.sparta.bubbleclub.global.security.web.dto.MemberPrincipal
 import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
@@ -42,12 +43,20 @@ class BubbleController(
         return ResponseEntity.ok().body(URI.create(String.format("/api/v1/bubbles/%d", id)))
     }
 
+    @GetMapping("/search")
+    fun searchBubbles(
+        @RequestParam bubbleId: Long?,
+        @Valid request: SearchKeywordRequest
+    ): ResponseEntity<Slice<BubbleResponse>> {
+        return ResponseEntity.ok()
+            .body(bubbleService.searchBubbles(bubbleId, request.keyword, PageRequest.of(0, 10)))
+    }
+
     @GetMapping
     fun getBubbles(
-        @RequestParam bubbleId: Long?,
-        @RequestParam(value = "keyword") keyword: String?
+        @RequestParam bubbleId: Long?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubblesByKeyword(bubbleId, keyword, PageRequest.of(0, 10)))
+        return ResponseEntity.ok().body(bubbleService.getBubbles(bubbleId, PageRequest.of(0, 10)))
     }
 
     @DeleteMapping("/{bubbleId}")

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
@@ -1,13 +1,19 @@
 package com.sparta.bubbleclub.domain.bubble.controller
 
+import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
-import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v2/bubbles")
@@ -15,11 +21,19 @@ class BubbleControllerV2(
     private val bubbleService: BubbleService
 ) {
 
+    @GetMapping("/search")
+    fun searchBubbles(
+        @RequestParam bubbleId: Long?,
+        @Valid request: SearchKeywordRequest
+    ): ResponseEntity<Slice<BubbleResponse>> {
+        return ResponseEntity.ok()
+            .body(bubbleService.searchBubblesWithCaching(bubbleId, request.keyword, PageRequest.of(0, 10)))
+    }
+
     @GetMapping
     fun getBubbles(
-        @RequestParam bubbleId: Long?,
-        @RequestParam(value = "keyword") keyword: String?
+        @RequestParam bubbleId: Long?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubblesByKeywordWithCaching(bubbleId, keyword, PageRequest.of(0, 10)))
+        return ResponseEntity.ok().body(bubbleService.getBubblesWithCaching(bubbleId, PageRequest.of(0, 10)))
     }
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/request/SearchKeywordRequest.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/request/SearchKeywordRequest.kt
@@ -1,0 +1,7 @@
+package com.sparta.bubbleclub.domain.bubble.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class SearchKeywordRequest(
+    @NotBlank(message = "공백이 아닌 검색어를 입력해주세요") val keyword: String,
+)

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
@@ -5,5 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface BubbleQueryDslRepository {
-    fun getBubblesByKeyword(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>
+
+    fun getBubbles(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse>
+    fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
@@ -38,13 +38,22 @@ class BubbleService(
         return bubble.id!!
     }
 
-    fun getBubblesByKeyword(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse> {
-        return bubbleRepository.getBubblesByKeyword(bubbleId, keyword, pageable)
+    fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
+        return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
     }
 
-    @Cacheable(cacheNames = ["bubbles"], key = "(#keyword ?: '').concat(#bubbleId ?: '')")
-    fun getBubblesByKeywordWithCaching(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
-        return bubbleRepository.getBubblesByKeyword(bubbleId, keyword, pageable)
+    fun getBubbles(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse> {
+        return bubbleRepository.getBubbles(bubbleId, pageable)
+    }
+
+    @Cacheable(value = ["bubbles"], key = "#keyword", condition = "#bubbleId == null")
+    fun searchBubblesWithCaching(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
+        return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
+    }
+
+    @Cacheable(value = ["bubbles"], key = "''", condition = "#bubbleId == null")
+    fun getBubblesWithCaching(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse> {
+        return bubbleRepository.getBubbles(bubbleId, pageable)
     }
 
     @Transactional


### PR DESCRIPTION
## 연관 이슈
- closes #29 

## 해당 작업을 한 동기는 무엇인가요?
- 단순 조회 시 화면과 검색 화면을 분리하고 각 경우에 캐싱 전략을 다르게 적용할 예정

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] Bubble 단순 조회/검색 API 분리
    - service, persistence layer의 관련 코드 변경
- 기타 작업 사항: validation 종속성 추가 및 검색 keyword 검증
