### PR TITLE
Feat 인기검색어 목록 조회 및 저장기능 추가

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/entity/Bubble.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/entity/Bubble.kt
@@ -27,10 +27,6 @@ class Bubble(
     var member: Member = member
         private set
 
-    fun updateContent(content: String) {
-        this.content = content
-    }
-
     fun update(request: UpdateBubbleRequest) {
         content = request.content
     }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
@@ -4,6 +4,7 @@ import com.sparta.bubbleclub.domain.bubble.dto.request.CreateBubbleRequest
 import com.sparta.bubbleclub.domain.bubble.dto.request.UpdateBubbleRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.repository.BubbleRepository
+import com.sparta.bubbleclub.domain.keyword.service.KeywordService
 import com.sparta.bubbleclub.domain.member.repository.MemberRepository
 import com.sparta.bubbleclub.global.exception.common.NoSuchEntityException
 import com.sparta.bubbleclub.global.security.web.dto.MemberPrincipal
@@ -17,7 +18,8 @@ import org.springframework.stereotype.Service
 @Service
 class BubbleService(
     private val bubbleRepository: BubbleRepository,
-    private val memberRepository: MemberRepository
+    private val memberRepository: MemberRepository,
+    private val keywordService: KeywordService
 ) {
     @Transactional
     fun save(memberPrincipal: MemberPrincipal, request: CreateBubbleRequest): Long {
@@ -38,7 +40,9 @@ class BubbleService(
         return bubble.id!!
     }
 
+    @Transactional
     fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
+        keyword?.let { keywordService.increaseKeywordCount(keyword) }
         return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
     }
 
@@ -46,8 +50,10 @@ class BubbleService(
         return bubbleRepository.getBubbles(bubbleId, pageable)
     }
 
+    @Transactional
     @Cacheable(value = ["bubbles"], key = "#keyword", condition = "#bubbleId == null")
     fun searchBubblesWithCaching(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
+        keyword?.let { keywordService.increaseKeywordCount(keyword) }
         return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
     }
 

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/controller/KeywordController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/controller/KeywordController.kt
@@ -1,0 +1,21 @@
+package com.sparta.bubbleclub.domain.keyword.controller
+
+import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
+import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
+import com.sparta.bubbleclub.domain.keyword.service.KeywordService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/v1/keywords")
+class KeywordController(
+    private val keywordService: KeywordService
+) {
+
+    @GetMapping
+    fun getPopularKeywords(): ResponseEntity<List<KeywordResponse>> {
+        return ResponseEntity.ok().body(keywordService.getPopularKeywords())
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/dto/response/KeywordResponse.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/dto/response/KeywordResponse.kt
@@ -1,0 +1,11 @@
+package com.sparta.bubbleclub.domain.keyword.dto.response
+
+import com.sparta.bubbleclub.domain.keyword.entity.KeywordStore
+
+data class KeywordResponse(
+    val keyword: String
+) {
+    companion object {
+        fun toResponse(keywordStore: KeywordStore) = KeywordResponse(keyword = keywordStore.keyword)
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/entity/KeywordStore.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/entity/KeywordStore.kt
@@ -1,0 +1,24 @@
+package com.sparta.bubbleclub.domain.keyword.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "keywords")
+class KeywordStore(
+    keyword: String,
+    count: Long
+) {
+
+    @Id
+    @Column(name = "keyword_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    @Column(name = "keyword")
+    val keyword: String = keyword
+
+    @Column(name = "count")
+    var count: Long = count
+
+    fun increaseCount() = this.count++
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepository.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepository.kt
@@ -1,0 +1,7 @@
+package com.sparta.bubbleclub.domain.keyword.repository
+
+import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
+
+interface KeywordQueryDslRepository {
+    fun getPopularKeywords(): List<KeywordResponse>
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.sparta.bubbleclub.domain.keyword.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sparta.bubbleclub.domain.keyword.QKeywordStore
+import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
+
+class KeywordQueryDslRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : KeywordQueryDslRepository {
+
+    private val keywordStore: QKeywordStore = QKeywordStore.keywordStore
+
+    override fun getPopularKeywords(): List<KeywordResponse> {
+        return queryFactory.selectFrom(keywordStore)
+            .orderBy(keywordStore.count.desc())
+            .limit(10)
+            .fetch()
+            .map { KeywordResponse.toResponse(it) }
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordRepository.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordRepository.kt
@@ -1,0 +1,10 @@
+package com.sparta.bubbleclub.domain.keyword.repository
+
+import com.sparta.bubbleclub.domain.keyword.entity.KeywordStore
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface KeywordRepository : JpaRepository<KeywordStore, Long>, KeywordQueryDslRepository {
+    fun findByKeyword(keyword: String): KeywordStore?
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
@@ -1,0 +1,24 @@
+package com.sparta.bubbleclub.domain.keyword.service
+
+import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
+import com.sparta.bubbleclub.domain.keyword.repository.KeywordRepository
+import com.sparta.bubbleclub.global.exception.common.NoSuchEntityException
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class KeywordService(
+    private val keywordRepository: KeywordRepository
+) {
+
+    @Transactional
+    fun increaseKeywordCount(keyword: String) {
+        val keyword = keywordRepository.findByKeyword(keyword) ?: throw NoSuchEntityException(errorMessage = "해당하는 Keyword는 없습니다")
+
+        keyword.increaseCount()
+    }
+
+    fun getPopularKeywords(): List<KeywordResponse> {
+        return keywordRepository.getPopularKeywords()
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- closes #31 

## 해당 작업을 한 동기는 무엇인가요?
- 인기 검색어 목록 조회 기능과 목록 조회 기능의 기반이 될 검색어 저장 기능을 추가했습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] KeywordStore 엔티티 추가
- [x] 인기 검색어 목록 조회를 하기 위한 QueryDsl 적용
- [x] 검색 시, 키워드 score 증가 로직 작성
- [x] Bubble 엔티티 불필요 업데이트 메서드 삭제