### PR TITLE
Refactor: 인기검색어 목록 조회 및 저장기능 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
@@ -5,21 +5,21 @@ import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.bubble.dto.request.UpdateBubbleRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
+import com.sparta.bubbleclub.domain.keyword.service.KeywordService
 import com.sparta.bubbleclub.global.security.web.dto.MemberPrincipal
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Size
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import java.net.URI
 
 @RestController
 @RequestMapping("/api/v1/bubbles")
 class BubbleController(
-    private val bubbleService: BubbleService
+    private val bubbleService: BubbleService,
+    private val keywordService: KeywordService
 ) {
 
     @PostMapping
@@ -48,15 +48,17 @@ class BubbleController(
         @RequestParam bubbleId: Long?,
         @Valid request: SearchKeywordRequest
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok()
-            .body(bubbleService.searchBubbles(bubbleId, request.keyword, PageRequest.of(0, 10)))
+        keywordService.increaseKeywordCount(request)
+        val response = bubbleService.searchBubbles(bubbleId, request.keyword, PageRequest.of(0, 10))
+        return ResponseEntity.ok().body(response)
     }
 
     @GetMapping
     fun getBubbles(
         @RequestParam bubbleId: Long?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubbles(bubbleId, PageRequest.of(0, 10)))
+        val response = bubbleService.getBubbles(bubbleId, PageRequest.of(0, 10))
+        return ResponseEntity.ok().body(response)
     }
 
     @DeleteMapping("/{bubbleId}")

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
@@ -3,14 +3,12 @@ package com.sparta.bubbleclub.domain.bubble.controller
 import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
+import com.sparta.bubbleclub.domain.keyword.service.KeywordService
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Size
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -18,7 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v2/bubbles")
 class BubbleControllerV2(
-    private val bubbleService: BubbleService
+    private val bubbleService: BubbleService,
+    private val keywordService: KeywordService
 ) {
 
     @GetMapping("/search")
@@ -26,14 +25,16 @@ class BubbleControllerV2(
         @RequestParam bubbleId: Long?,
         @Valid request: SearchKeywordRequest
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok()
-            .body(bubbleService.searchBubblesWithCaching(bubbleId, request.keyword, PageRequest.of(0, 10)))
+        keywordService.increaseKeywordCount(request)
+        val response = bubbleService.searchBubblesWithCaching(bubbleId, request.keyword, PageRequest.of(0, 10))
+        return ResponseEntity.ok().body(response)
     }
 
     @GetMapping
     fun getBubbles(
         @RequestParam bubbleId: Long?
     ): ResponseEntity<Slice<BubbleResponse>> {
-        return ResponseEntity.ok().body(bubbleService.getBubblesWithCaching(bubbleId, PageRequest.of(0, 10)))
+        val response = bubbleService.getBubblesWithCaching(bubbleId, PageRequest.of(0, 10))
+        return ResponseEntity.ok().body(response)
     }
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/request/SearchKeywordRequest.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/request/SearchKeywordRequest.kt
@@ -1,7 +1,10 @@
 package com.sparta.bubbleclub.domain.bubble.dto.request
 
+import com.sparta.bubbleclub.domain.keyword.entity.KeywordStore
 import jakarta.validation.constraints.NotBlank
 
 data class SearchKeywordRequest(
     @NotBlank(message = "공백이 아닌 검색어를 입력해주세요") val keyword: String,
-)
+) {
+    fun toEntity() = KeywordStore(keyword = keyword, count = 0)
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
@@ -42,7 +42,6 @@ class BubbleService(
 
     @Transactional
     fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
-        keyword?.let { keywordService.increaseKeywordCount(keyword) }
         return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
     }
 
@@ -53,7 +52,6 @@ class BubbleService(
     @Transactional
     @Cacheable(value = ["bubbles"], key = "#keyword", condition = "#bubbleId == null")
     fun searchBubblesWithCaching(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>? {
-        keyword?.let { keywordService.increaseKeywordCount(keyword) }
         return bubbleRepository.searchBubbles(bubbleId, keyword, pageable)
     }
 

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/service/BubbleService.kt
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service
 class BubbleService(
     private val bubbleRepository: BubbleRepository,
     private val memberRepository: MemberRepository,
-    private val keywordService: KeywordService
 ) {
     @Transactional
     fun save(memberPrincipal: MemberPrincipal, request: CreateBubbleRequest): Long {

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/controller/KeywordController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/controller/KeywordController.kt
@@ -1,6 +1,5 @@
 package com.sparta.bubbleclub.domain.keyword.controller
 
-import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
 import com.sparta.bubbleclub.domain.keyword.service.KeywordService
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordQueryDslRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.sparta.bubbleclub.domain.keyword.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.sparta.bubbleclub.domain.keyword.QKeywordStore
+import com.sparta.bubbleclub.domain.keyword.entity.QKeywordStore
 import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
 
 class KeywordQueryDslRepositoryImpl(

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
@@ -1,8 +1,8 @@
 package com.sparta.bubbleclub.domain.keyword.service
 
+import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
 import com.sparta.bubbleclub.domain.keyword.repository.KeywordRepository
-import com.sparta.bubbleclub.global.exception.common.NoSuchEntityException
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 
@@ -12,8 +12,8 @@ class KeywordService(
 ) {
 
     @Transactional
-    fun increaseKeywordCount(keyword: String) {
-        val keyword = keywordRepository.findByKeyword(keyword) ?: throw NoSuchEntityException(errorMessage = "해당하는 Keyword는 없습니다")
+    fun increaseKeywordCount(request: SearchKeywordRequest) {
+        val keyword = keywordRepository.findByKeyword(request.keyword) ?: keywordRepository.save(request.toEntity())
 
         keyword.increaseCount()
     }


### PR DESCRIPTION
## 연관 이슈
- closes #35 

## 해당 작업을 한 동기는 무엇인가요?
- BubbleService <> KeywordService 간 순환참조를 방지하기 위해 의존 관계를 Service에서 Service로 가는 것이 아닌, Controller 에서 Service를 의존하는 관계로 변경하였습니다.
- MethodArgumentNotValidException 예외 정상 호출을 위한 이메일 정규식 변경을 하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [ ] 컨트롤러에서 같은 트랜잭션을 타게 하는 것이 아니라 서로 다른 두 개의 트랜잭션을 타고 있기 때문에 키워드 저장은 완료되도, 검색은 조회되지 않을 수 있는 이슈가 생길 수 있다고 생각하는데 어떻게 생각하시나요!

