### PR TITLE
✨ Feat: Redis 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,11 +41,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.querydsl:querydsl-jpa:$queryDslVersion:jakarta") // querydsl
     kapt("com.querydsl:querydsl-apt:$queryDslVersion:jakarta") // querydsl
+    implementation ("org.springframework.boot:spring-boot-starter-data-redis") // redis
 
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
-    runtimeOnly("com.h2database:h2")
-//    runtimeOnly("com.mysql:mysql-connector-j")
+//    runtimeOnly("com.h2database:h2")
+    runtimeOnly("com.mysql:mysql-connector-j")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleControllerV2.kt
@@ -2,6 +2,7 @@ package com.sparta.bubbleclub.domain.bubble.controller
 
 import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
+import com.sparta.bubbleclub.domain.bubble.dto.response.CustomSliceImpl
 import com.sparta.bubbleclub.domain.bubble.service.BubbleService
 import com.sparta.bubbleclub.domain.keyword.service.KeywordService
 import jakarta.validation.Valid
@@ -24,7 +25,7 @@ class BubbleControllerV2(
     fun searchBubbles(
         @RequestParam bubbleId: Long?,
         @Valid request: SearchKeywordRequest
-    ): ResponseEntity<Slice<BubbleResponse>> {
+    ): ResponseEntity<CustomSliceImpl<BubbleResponse>> {
         keywordService.increaseKeywordCount(request)
         val response = bubbleService.searchBubblesWithCaching(bubbleId, request.keyword, PageRequest.of(0, 10))
         return ResponseEntity.ok().body(response)

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/response/BubbleResponse.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/response/BubbleResponse.kt
@@ -1,5 +1,6 @@
 package com.sparta.bubbleclub.domain.bubble.dto.response
 
+import java.io.Serializable
 import java.time.ZonedDateTime
 
 data class BubbleResponse(
@@ -7,4 +8,4 @@ data class BubbleResponse(
     val content: String,
     val nickname: String,
     val createdAt: ZonedDateTime
-)
+): Serializable

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/response/CustomSliceImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/dto/response/CustomSliceImpl.kt
@@ -1,0 +1,19 @@
+package com.sparta.bubbleclub.domain.bubble.dto.response
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
+import org.springframework.data.domain.Pageable
+
+class CustomSliceImpl<T> @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
+    @JsonProperty("content") content: List<T>?,
+    @JsonProperty("size") size: Int,
+    @JsonProperty("hasNext") hasNext: Boolean
+) : SliceImpl<T>(content!!, PageRequest.of(0, size), hasNext) {
+    @JsonIgnore
+    override fun getPageable(): Pageable {
+        return super.getPageable()
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
@@ -1,11 +1,12 @@
 package com.sparta.bubbleclub.domain.bubble.repository
 
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
+import com.sparta.bubbleclub.domain.bubble.dto.response.CustomSliceImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface BubbleQueryDslRepository {
 
     fun getBubbles(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse>
-    fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse>
+    fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): CustomSliceImpl<BubbleResponse>
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
@@ -4,10 +4,10 @@ import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
+import com.sparta.bubbleclub.domain.bubble.dto.response.CustomSliceImpl
 import com.sparta.bubbleclub.domain.bubble.entity.QBubble
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
-import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -39,8 +39,8 @@ class BubbleQueryDslRepositoryImpl(
         return checkLastPage(pageable, result)
     }
 
-    // 커서기반 페이징, keyword like 조건 (keyword 인기 검색어 )
-    override fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): Slice<BubbleResponse> {
+    // 커서기반 페이징
+    override fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): CustomSliceImpl<BubbleResponse> {
         val pageSize = pageable.pageSize.toLong()
         val result = queryFactory.select(
             Projections.constructor(
@@ -81,15 +81,14 @@ class BubbleQueryDslRepositoryImpl(
     }
 
     // 마지막 페이지 확인
-    private fun checkLastPage(pageable: Pageable, result: MutableList<BubbleResponse>): Slice<BubbleResponse> {
+    private fun checkLastPage(pageable: Pageable, result: MutableList<BubbleResponse>): CustomSliceImpl<BubbleResponse> {
 
         var hasNext = false
         if(result.size > pageable.pageSize ) {
             result.removeAt(result.size-1)
             hasNext = true
         }
-
-        return SliceImpl<BubbleResponse>(result, pageable, hasNext)
+        return CustomSliceImpl<BubbleResponse>(result, pageable.pageSize, hasNext)
     }
 
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/dto/response/KeywordResponse.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/dto/response/KeywordResponse.kt
@@ -7,5 +7,6 @@ data class KeywordResponse(
 ) {
     companion object {
         fun toResponse(keywordStore: KeywordStore) = KeywordResponse(keyword = keywordStore.keyword)
+        fun toResponse(keywordStore: String) = KeywordResponse(keyword = keywordStore)
     }
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
@@ -4,21 +4,35 @@ import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
 import com.sparta.bubbleclub.domain.keyword.repository.KeywordRepository
 import jakarta.transaction.Transactional
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 
 @Service
 class KeywordService(
-    private val keywordRepository: KeywordRepository
+    private val keywordRepository: KeywordRepository,
+    private val redisTemplate: RedisTemplate<String, String>
 ) {
+
+    private val zSetOperations = redisTemplate.opsForZSet()
+    companion object {
+        private const val REDIS_KEY = "keyword"
+    }
 
     @Transactional
     fun increaseKeywordCount(request: SearchKeywordRequest) {
-        val keyword = keywordRepository.findByKeyword(request.keyword) ?: keywordRepository.save(request.toEntity())
+        // redis에 이 keyword 있는지 검사, 없으면 추가
+       zSetOperations.addIfAbsent(REDIS_KEY, request.keyword, 0.0)
 
-        keyword.increaseCount()
+        // score ++
+        increaseScore(request.keyword)
     }
 
     fun getPopularKeywords(): List<KeywordResponse> {
-        return keywordRepository.getPopularKeywords()
+        val rank = zSetOperations.reverseRange(REDIS_KEY, 0, 9) as Set<String>?
+        return rank?.map { KeywordResponse.toResponse(it) } ?: keywordRepository.getPopularKeywords()
+    }
+
+    private fun increaseScore(keyword: String) {
+        zSetOperations.incrementScore(REDIS_KEY, keyword, 1.0)
     }
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/member/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/member/dto/SignupRequest.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 
 data class SignupRequest(
-    @field:Pattern(regexp = "^(.+)@(\\S+) \$.", message = "올바른 이메일 형식을 입력해주세요")
+    @field:Pattern(regexp = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", message = "올바른 이메일 형식을 입력해주세요")
     val email: String,
 
     @field:Pattern(

--- a/src/main/kotlin/com/sparta/bubbleclub/global/config/CachingConfig.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/config/CachingConfig.kt
@@ -1,15 +1,8 @@
 package com.sparta.bubbleclub.global.config
 
-import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @EnableCaching
 @Configuration
-class CachingConfig {
-
-    @Bean
-    fun cacheManager(): CacheManager = ConcurrentMapCacheManager("bubbles")
-}
+class CachingConfig

--- a/src/main/kotlin/com/sparta/bubbleclub/global/config/PropertyConfig.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/config/PropertyConfig.kt
@@ -5,5 +5,5 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(JwtProperties::class)
-class JwtPropertyConfig
+@EnableConfigurationProperties(JwtProperties::class, RedisProperties::class)
+class PropertyConfig

--- a/src/main/kotlin/com/sparta/bubbleclub/global/config/RedisConfig.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/config/RedisConfig.kt
@@ -1,0 +1,54 @@
+package com.sparta.bubbleclub.infra.redis
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties
+import org.springframework.cache.CacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig(
+    private val redisProperties: RedisProperties
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory {
+        return LettuceConnectionFactory(redisProperties.host, redisProperties.port)
+    }
+
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, String> {
+        val redisTemplate = RedisTemplate<String, String>()
+        redisTemplate.connectionFactory = redisConnectionFactory()
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+        return redisTemplate
+    }
+
+
+    @Bean
+    fun redisCacheManager(): CacheManager {
+        val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory())
+            .cacheDefaults(cacheConfig)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/config/RedisProperties.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/config/RedisProperties.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+class RedisProperties(
+    val host: String,
+    val port: Int
+)


### PR DESCRIPTION


## 연관 이슈
- closes #41 

## 해당 작업을 한 동기는 무엇인가요?
- Redis 를 사용해서 인기 검색어 목록 조회와 버블 전체 조회 및 키워드 검색 기능의 첫 페이지 캐싱을 적용해서 성능을 높이기 위함입니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- CustomSliceImpl 생성, 반환값 변경 (pageable 직렬화 문제)
- Redis 의존성 추가
- RedisConfig 설정
- RedisProperties 추가
- KeywordService, BubbleService -> RedisTemplate 주입 -BubbleResponse: Serializable 상속
- CachingConfig 로컬 캐시 매니저 삭제