### PR TITLE
Refactor: Redis 캐시 적용 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
@@ -34,12 +34,10 @@ class KeywordService(
     }
 
     @Transactional
-    @Scheduled(fixedDelay = 1000 * 60 * 10)
+    @Scheduled(fixedDelay = 1000 * 60 * 10, initialDelay = 1000 * 60 * 10)
     fun flushAllCache() {
         zSetOperations.reverseRangeWithScores(POPULAR_KEYWORDS, 0, 9)
-            .let {
-                it?.map { keyword -> KeywordStore(keyword.value!!, keyword.score!!.toLong(), ZonedDateTime.now()) }
-            }
+            ?.map { KeywordStore(it.value!!, it.score!!.toLong(), ZonedDateTime.now()) }
             ?.also { keywords -> keywordRepository.saveAll(keywords) }
 
         zSetOperations.removeRange(POPULAR_KEYWORDS, 0, zSetOperations.size(POPULAR_KEYWORDS)?.minus(1) ?: 0)

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/keyword/service/KeywordService.kt
@@ -4,6 +4,7 @@ import com.sparta.bubbleclub.domain.bubble.dto.request.SearchKeywordRequest
 import com.sparta.bubbleclub.domain.keyword.dto.response.KeywordResponse
 import com.sparta.bubbleclub.domain.keyword.entity.KeywordStore
 import com.sparta.bubbleclub.domain.keyword.repository.KeywordRepository
+import com.sparta.bubbleclub.infra.redis.CacheKey.POPULAR_KEYWORDS
 import jakarta.transaction.Transactional
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
@@ -18,38 +19,34 @@ class KeywordService(
 
     private val zSetOperations = redisTemplate.opsForZSet()
 
-    companion object {
-        private const val REDIS_KEY = "keyword"
-    }
-
     @Transactional
     fun increaseKeywordCount(request: SearchKeywordRequest) {
         // redis에 이 keyword 있는지 검사, 없으면 추가
-        zSetOperations.addIfAbsent(REDIS_KEY, request.keyword, 0.0)
+        zSetOperations.addIfAbsent(POPULAR_KEYWORDS, request.keyword, 0.0)
 
         // score ++
         increaseScore(request.keyword)
     }
 
     fun getPopularKeywords(): List<KeywordResponse> {
-        val rank = zSetOperations.reverseRange(REDIS_KEY, 0, 9) as Set<String>?
+        val rank = zSetOperations.reverseRange(POPULAR_KEYWORDS, 0, 9) as Set<String>?
         return rank?.map { KeywordResponse.toResponse(it) } ?: keywordRepository.getPopularKeywords()
     }
 
     @Transactional
     @Scheduled(fixedDelay = 1000 * 60 * 10)
     fun flushAllCache() {
-        zSetOperations.reverseRangeWithScores(REDIS_KEY, 0, 9)
+        zSetOperations.reverseRangeWithScores(POPULAR_KEYWORDS, 0, 9)
             .let {
                 it?.map { keyword -> KeywordStore(keyword.value!!, keyword.score!!.toLong(), ZonedDateTime.now()) }
             }
             ?.also { keywords -> keywordRepository.saveAll(keywords) }
 
-        zSetOperations.removeRange(REDIS_KEY, 0, zSetOperations.size(REDIS_KEY)?.minus(1) ?: 0)
+        zSetOperations.removeRange(POPULAR_KEYWORDS, 0, zSetOperations.size(POPULAR_KEYWORDS)?.minus(1) ?: 0)
     }
 
     private fun increaseScore(keyword: String) {
-        zSetOperations.incrementScore(REDIS_KEY, keyword, 1.0)
+        zSetOperations.incrementScore(POPULAR_KEYWORDS, keyword, 1.0)
     }
 
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/infra/redis/CacheKey.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/infra/redis/CacheKey.kt
@@ -1,0 +1,10 @@
+package com.sparta.bubbleclub.infra.redis
+
+object CacheKey {
+    // 전체 조회
+    const val GET_ALL_BUBBLES = "BUBBLES"
+    // 키워드 검색 조회
+    const val GET_BUBBLES_BY_KEYWORD = "KEYWORD"
+    // 인기 검색어 목록
+    const val POPULAR_KEYWORDS = "POPULARS"
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/infra/redis/RedisConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
@@ -32,8 +33,8 @@ class RedisConfig(
         return redisTemplate
     }
 
-    @Bean(name = ["cacheManager"])
-    fun redisCacheManager(): CacheManager {
+    @Bean
+    fun cacheManager(): CacheManager {
         val cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(
@@ -42,7 +43,7 @@ class RedisConfig(
             )
             .serializeValuesWith(
                 RedisSerializationContext.SerializationPair.fromSerializer(
-                    StringRedisSerializer()
+                    JdkSerializationRedisSerializer()
                 )
             )
         return RedisCacheManager.RedisCacheManagerBuilder
@@ -50,4 +51,5 @@ class RedisConfig(
             .cacheDefaults(cacheConfig)
             .build()
     }
+
 }


### PR DESCRIPTION
## 연관 이슈
- closes #45 

## 해당 작업을 한 동기는 무엇인가요?
- CacheKey 적용은 캐시 키를 한 곳에서 관리하기 편하게 하기 위해 적용하였습니다.
- @Cahceable, @CacheEvict를 함께 사용하기 위해 RedisCacheManager를 사용하여 캐시 정책을 충분히 구현할 수 있고, 비즈니스 로직에 캐시 관련 로직을 함께 포함시키지 않는 것이 좋다고 생각이 들어 BubbleService에서 redisTemplate을 제거하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] 레디스 캐시 키를 클래스를 통해서 관리하게 끔 적용하였습니다.
- [x] 조회시 첫 페이지만 캐시하고, 그 후에 Bubble의 등록, 수정, 삭제가 발생할 때 조회된 데이터를 캐시에서 삭제하는 정책을 적용하기로 팀원과 협의한 뒤, 기존에 사용하던 RedisTemplate을 제거하고 CacheManager를 적용하는 것이 더 좋다고 생각하였습니다.
  - 첫 페이지만 캐시하는 것이기 때문에 자료구조는 Redis의 String만 사용해도 충분할 것이라고 생각이 들었고, StringRedisSerializer에서 JdkSerializationRedisSerializer로 변경을 한 것은 직렬화/역직렬화 문제가 있었기 때문입니다.
  - JdkSerializationRedisSerializer를 사용하면 객체가 변경되면 역직렬화가 불가능하고, 상대적으로 저장하는 데이터의 용량이 커져 부담이 될 수도 있지만, 첫 페이지만 캐시하기 때문에 용량은 크게 신경쓰지 않아도 될 것 같아 적용하기로 하였습니다.
  - Spring-starter-cache에서 제공하는 @Cacheable, @CacheEvict를 사용하는 것이 비즈니스 로직과 캐시 적용 로직의 분리에 더욱 용이하고, 직관적으로 파악하기 쉽겠다고 생각하였습니다.
- [x] 또한 EC2에 ElasticCache를 적용하여 Redis를 클라우드 환경에 사용할 수 있도록 적용하였습니다.