### PR TITLE
Test: KeywordRepository getPopularKeywords() 테스트

### DIFF
--- a/src/test/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordRepositoryTest.kt
+++ b/src/test/kotlin/com/sparta/bubbleclub/domain/keyword/repository/KeywordRepositoryTest.kt
@@ -1,8 +1,38 @@
 package com.sparta.bubbleclub.domain.keyword.repository
 
+import com.sparta.bubbleclub.fixture.keyword.KeywordFixture
+import com.sparta.bubbleclub.global.TestQueryDslConfig
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
 
-class KeywordRepositoryTest : BehaviorSpec({
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(value = [TestQueryDslConfig::class])
+@TestPropertySource("classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class KeywordRepositoryTest(
+    private val keywordRepository: KeywordRepository
+) : BehaviorSpec({
 
-    given("getPopularKeywords") { }
+    Given("15개의 검색어가 목록에 있을 때") {
+        val keywordList = KeywordFixture.keywordList
+        keywordRepository.saveAll(keywordList)
+
+        val sortedList = keywordList.sortedByDescending { it.count }
+
+        When("인기 검색어 목록을 조회하면") {
+            val result = keywordRepository.getPopularKeywords()
+
+            Then("10개 이하의 인기 검색어가 count 높은 순으로 정렬되어 반환된다") {
+                result.size shouldBeLessThanOrEqual 10
+                result.zip(sortedList) { keywordResponse, keywordStore -> keywordResponse.keyword shouldBe keywordStore.keyword }
+            }
+        }
+    }
 })

--- a/src/test/kotlin/com/sparta/bubbleclub/fixture/keyword/KeywordFixture.kt
+++ b/src/test/kotlin/com/sparta/bubbleclub/fixture/keyword/KeywordFixture.kt
@@ -1,7 +1,19 @@
 package com.sparta.bubbleclub.fixture.keyword
 
 import com.appmattus.kotlinfixture.kotlinFixture
+import com.sparta.bubbleclub.domain.keyword.entity.KeywordStore
+import java.time.ZonedDateTime
 
 object KeywordFixture {
-    val fixture = kotlinFixture()
+
+    val fixture = kotlinFixture {
+        repeatCount { 15 }
+    }
+
+    val keywordList = fixture<List<KeywordStore>> {
+        generate()
+    }
+
+    fun generate(keyword: String = fixture(), count: Long = fixture(), createdAt: ZonedDateTime = fixture()) = KeywordStore(keyword, count, createdAt)
+
 }


### PR DESCRIPTION
## 연관 이슈
- closes #52 

## 해당 작업을 한 동기는 무엇인가요?
- Keword Repository 단위 테스트를 하기 위해서입니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] 15개의 KeywordStore list fixture 생성
- [x] getPopularKeywords() 단위 테스트 작성
 - 15개의 검색어가 목록에 있을 때 인기 검색어 목록을 조회하면 10개 이하의 인기 검색어가 count 높은 순으로 정렬되어 반환된다.