### PR TITLE
refactor: BubbleService 리팩토링

### DIFF
--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/controller/BubbleController.kt
@@ -36,9 +36,10 @@ class BubbleController(
     @PatchMapping("/{bubbleId}")
     fun updateBubble(
         @PathVariable bubbleId: Long,
-        @RequestBody @Valid request: UpdateBubbleRequest
+        @RequestBody @Valid request: UpdateBubbleRequest,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal,
     ): ResponseEntity<URI> {
-        val id = bubbleService.update(bubbleId, request)
+        val id = bubbleService.update(bubbleId, request, memberPrincipal)
 
         return ResponseEntity.ok().body(URI.create(String.format("/api/v1/bubbles/%d", id)))
     }
@@ -62,8 +63,11 @@ class BubbleController(
     }
 
     @DeleteMapping("/{bubbleId}")
-    fun deleteBubble(@PathVariable bubbleId: Long): ResponseEntity<Unit> {
-        bubbleService.delete(bubbleId)
+    fun deleteBubble(
+        @PathVariable bubbleId: Long,
+        @AuthenticationPrincipal memberPrincipal: MemberPrincipal
+    ): ResponseEntity<Unit> {
+        bubbleService.delete(bubbleId, memberPrincipal)
 
         return ResponseEntity.noContent().build()
     }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepository.kt
@@ -3,10 +3,9 @@ package com.sparta.bubbleclub.domain.bubble.repository
 import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.dto.response.CustomSliceImpl
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 
 interface BubbleQueryDslRepository {
 
-    fun getBubbles(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse>
+    fun getBubbles(bubbleId: Long?, pageable: Pageable): CustomSliceImpl<BubbleResponse>
     fun searchBubbles(bubbleId: Long?, keyword: String?, pageable: Pageable): CustomSliceImpl<BubbleResponse>
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/domain/bubble/repository/BubbleQueryDslRepositoryImpl.kt
@@ -7,7 +7,6 @@ import com.sparta.bubbleclub.domain.bubble.dto.response.BubbleResponse
 import com.sparta.bubbleclub.domain.bubble.dto.response.CustomSliceImpl
 import com.sparta.bubbleclub.domain.bubble.entity.QBubble
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -17,7 +16,7 @@ class BubbleQueryDslRepositoryImpl(
 
     private val bubble: QBubble = QBubble.bubble
 
-    override fun getBubbles(bubbleId: Long?, pageable: Pageable): Slice<BubbleResponse> {
+    override fun getBubbles(bubbleId: Long?, pageable: Pageable): CustomSliceImpl<BubbleResponse> {
         val pageSize = pageable.pageSize.toLong()
         val result = queryFactory.select(
             Projections.constructor(
@@ -36,7 +35,7 @@ class BubbleQueryDslRepositoryImpl(
             .limit(pageSize + 1)
             .fetch()
 
-        return checkLastPage(pageable, result)
+        return checkLastPage(result, pageable)
     }
 
     // 커서기반 페이징
@@ -60,7 +59,7 @@ class BubbleQueryDslRepositoryImpl(
             .limit(pageSize + 1)
             .fetch()
 
-        return checkLastPage(pageable, result)
+        return checkLastPage(result, pageable)
     }
 
     // id 보다 작은 bubbles
@@ -81,9 +80,10 @@ class BubbleQueryDslRepositoryImpl(
     }
 
     // 마지막 페이지 확인
-    private fun checkLastPage(pageable: Pageable, result: MutableList<BubbleResponse>): CustomSliceImpl<BubbleResponse> {
+    private fun checkLastPage(result: MutableList<BubbleResponse>, pageable: Pageable): CustomSliceImpl<BubbleResponse> {
 
         var hasNext = false
+
         if(result.size > pageable.pageSize ) {
             result.removeAt(result.size-1)
             hasNext = true

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CommonErrorCode.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/CommonErrorCode.kt
@@ -10,7 +10,9 @@ enum class CommonErrorCode(
 
     ENTITY_NOT_FOUND_ERR(HttpStatus.NOT_FOUND, "존재하지 않는 Entity 입니다"),
     INTERNAL_SERVER_ERR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생하였습니다."),
-    INVALID_ARGS_ERR(HttpStatus.BAD_REQUEST, "주어진 입력값이 올바르지 않습니다.");
+    INVALID_ARGS_ERR(HttpStatus.BAD_REQUEST, "주어진 입력값이 올바르지 않습니다."),
+    HAS_NO_PERMISSION(HttpStatus.FORBIDDEN, "권한이 존재하지 않습니다.")
 
+    ;
     override val errorName: String = name
 }

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/HasNoPermissionException.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/common/HasNoPermissionException.kt
@@ -1,0 +1,9 @@
+package com.sparta.bubbleclub.global.exception.common
+
+import com.sparta.bubbleclub.global.exception.code.ErrorCode
+
+class HasNoPermissionException(
+    override val errorCode: ErrorCode = CommonErrorCode.HAS_NO_PERMISSION,
+    override val errorMessage: String = errorCode.bodyMessage
+) : RestApiException() {
+}

--- a/src/main/kotlin/com/sparta/bubbleclub/global/exception/handler/RestApiExceptionHandler.kt
+++ b/src/main/kotlin/com/sparta/bubbleclub/global/exception/handler/RestApiExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.sparta.bubbleclub.global.exception.handler
 
 import com.sparta.bubbleclub.global.exception.common.CommonErrorCode
+import com.sparta.bubbleclub.global.exception.common.HasNoPermissionException
 import com.sparta.bubbleclub.global.exception.common.RestApiException
 import com.sparta.bubbleclub.global.exception.response.ErrorResponse
 import org.slf4j.LoggerFactory
@@ -30,6 +31,12 @@ class RestApiExceptionHandler {
     fun handleRestApiException(exception: RestApiException): ResponseEntity<ErrorResponse> {
         logger.warn(exception::class.simpleName, exception) // 추후 AOP 적용 예상
         return makeResponse(ErrorResponse.of(exception.errorCode, exception.errorMessage))
+    }
+
+    @ExceptionHandler
+    fun handleHasNoPermissionException(exception: HasNoPermissionException): ResponseEntity<ErrorResponse> {
+        logger.warn(exception::class.simpleName, exception)
+        return makeResponse(ErrorResponse.of(exception.errorCode))
     }
 
     private fun makeResponse(response: ErrorResponse): ResponseEntity<ErrorResponse> {


### PR DESCRIPTION
## 연관 이슈
- closes #57 

## 해당 작업을 한 동기는 무엇인가요?
- Update, Delete 동작에서 수정 또는 삭제하려는 Member와 현재 로그인 한 멤버의 ID를 비교하는 로직이 누락되어 이를 추가하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 가능한 상세히 설명해주세요
- [x] BubbleContoller, BubbleService ID 비교 로직 작성
- [x] HasNoPermissionException 클래스 작성 / RestApiHandler 예외 핸들링 추가 / CommonErrorCode 내용 추가
- [x] 리턴타입 통일을 위한 BubbleQueryDslRepositoryImpl, BubbleService 리턴 타입 수정